### PR TITLE
Adding execution of examples to tox test environments

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
           pip install tox
       - name: Run tests
         run: |
-          tox -e py
+          tox -e tests,examples
       - uses: codecov/codecov-action@v1
         with:
           file: ./tests/coverage.xml

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,0 +1,4 @@
+jupyter
+jupyter_contrib_nbextensions
+matplotlib
+tqdm

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ deps =
     tqdm
 
 commands =
-    bash -c "for f in *.ipynb; do jupyter nbconvert --execute "$f" --to python; done"
+    bash -c "for file in *.ipynb; do jupyter nbconvert --to notebook --output "../.tox/examples/$file" --execute "$file"; done"
 """
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,11 +22,7 @@ commands =
 changedir = examples
 allowlist_externals = /bin/bash
 
-deps =
-    jupyter
-    jupyter_contrib_nbextensions
-    matplotlib
-    tqdm
+deps = -rexamples/requirements.txt
 
 commands =
     bash -c "for file in *.ipynb; do jupyter nbconvert --to notebook --output "../.tox/examples/$file" --execute "$file"; done"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 legacy_tox_ini = """
 [tox]
 
-[testenv]
+[testenv:tests]
 changedir = tests
 deps =
     coverage[toml]
@@ -17,6 +17,19 @@ deps =
 commands =
     coverage run -m unittest discover -p "*.py"
     coverage xml
+
+[testenv:examples]
+changedir = examples
+allowlist_externals = /bin/bash
+
+deps =
+    jupyter
+    jupyter_contrib_nbextensions
+    matplotlib
+    tqdm
+
+commands =
+    bash -c "for f in *.ipynb; do jupyter nbconvert --execute "$f" --to python; done"
 """
 
 [tool.coverage.run]


### PR DESCRIPTION
Splitted the testenv into two one for tests and one for the examples.