### PR TITLE
enforcing most recent build of scikit-learn

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 numpy
-sklearn
+scikit-learn >=0.24.0
 sphinx >=3.3
 sphinx_rtd_theme

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ include_package_data = True
 zip_safe = True
 packages = find:
 install_requires = numpy
-                   sklearn
+                   scikit-learn>="0.24.0"
 
 [bdist_wheel]
 universal = 1


### PR DESCRIPTION
sklearn added an arpack initializer in 0.24.0 that was previously unavailable.

![image](https://user-images.githubusercontent.com/47536110/107514139-8cc07400-6ba9-11eb-8c1f-e0bd21d4f96e.png)
