### PR TITLE
Test and fix for issue #61

### DIFF
--- a/skcosmo/linear_model/_ridge.py
+++ b/skcosmo/linear_model/_ridge.py
@@ -194,14 +194,14 @@ class RidgeRegression2FoldCV(MultiOutputMixin, RegressorMixin):
 
         def _2fold_loss_cutoff(alpha):
             # error approximating X2 a-fitted model and vice versa
-            n_alpha_fold1 = min(n_fold1, len(s_fold1 > alpha))
+            n_alpha_fold1 = min(n_fold1, sum(s_fold1 > alpha))
             loss_1_to_2 = scorer(
                 identity_estimator,
                 y_fold2,
                 (X_fold2_V_fold1[:, :n_alpha_fold1] / s_fold1[:n_alpha_fold1])
                 @ Ut_fold1_y_fold1[:n_alpha_fold1],
             )
-            n_alpha_fold2 = min(n_fold2, len(s_fold2 > alpha))
+            n_alpha_fold2 = min(n_fold2, sum(s_fold2 > alpha))
             loss_2_to_1 = scorer(
                 identity_estimator,
                 y_fold1,

--- a/skcosmo/metrics/_reconstruction_measures.py
+++ b/skcosmo/metrics/_reconstruction_measures.py
@@ -606,7 +606,7 @@ def check_global_reconstruction_measures_input(
 
     if estimator is None:
         estimator = RidgeRegression2FoldCV(
-            alphas=[10 ** (i) for i in range(-5, 0)] + [0.5, 0.9],
+            alphas=np.geomspace(1e-9, 0.9, 20),
             alpha_type="relative",
             regularization_method="cutoff",
             random_state=0x5F3759DF,
@@ -642,7 +642,7 @@ def check_local_reconstruction_measures_input(
 
     if estimator is None:
         estimator = RidgeRegression2FoldCV(
-            alphas=[10 ** (i) for i in range(-5, 0)] + [0.5, 0.9],
+            alphas=np.geomspace(1e-9, 0.9, 20),
             alpha_type="relative",
             regularization_method="cutoff",
             random_state=0x5F3759DF,

--- a/tests/test_linear_model.py
+++ b/tests/test_linear_model.py
@@ -172,7 +172,6 @@ class RidgeTests(unittest.TestCase):
             f"error {err} surpasses threshold for zero {self.eps}",
         )
 
-
     @parameterized.expand(ridge_parameters)
     def test_ridge_regression_2fold_regularization(
         self, name, alpha_type, regularization_method
@@ -187,15 +186,15 @@ class RidgeTests(unittest.TestCase):
         if alpha_type == "absolute":
             alphas = singular_values[1:][::-1]
         if alpha_type == "relative":
-            alphas = (singular_values[1:][::-1]/singular_values[0])
+            alphas = singular_values[1:][::-1] / singular_values[0]
 
         # tests if RidgeRegression2FoldCV does do regularization correct
         ridge = RidgeRegression2FoldCV(
-                alphas=alphas,
-                alpha_type=alpha_type,
-                regularization_method=regularization_method,
-                scoring="neg_root_mean_squared_error"
-            ).fit(self.features_all, self.features_all)
+            alphas=alphas,
+            alpha_type=alpha_type,
+            regularization_method=regularization_method,
+            scoring="neg_root_mean_squared_error",
+        ).fit(self.features_all, self.features_all)
         twofold_rmse = -np.array(ridge.cv_values_)
 
         # since the data can be perfectly reconstructed,
@@ -203,12 +202,11 @@ class RidgeTests(unittest.TestCase):
         # larger errors
         error_grad = twofold_rmse[1:] - twofold_rmse[:-1]
         self.assertTrue(
-           np.all(error_grad > 0),
+            np.all(error_grad > 0),
             "error does not strictly increase with larger regularization\n"
             f"\ttwofold RMSE: {twofold_rmse}\n"
             f"\tregularization parameters: {ridge.alphas}",
         )
-
 
 
 if __name__ == "__main__":

--- a/tests/test_linear_model.py
+++ b/tests/test_linear_model.py
@@ -202,7 +202,7 @@ class RidgeTests(unittest.TestCase):
         # larger errors
         error_grad = twofold_rmse[1:] - twofold_rmse[:-1]
         self.assertTrue(
-            np.all(error_grad > 0),
+            np.all(error_grad > self.eps),
             "error does not strictly increase with larger regularization\n"
             f"\ttwofold RMSE: {twofold_rmse}\n"
             f"\tregularization parameters: {ridge.alphas}",


### PR DESCRIPTION
Quote issue #61

> https://github.com/cosmo-epfl/scikit-cosmo/blob/43658d3944e491a847ec571891b4b1375daa6d61/skcosmo/linear_model/_ridge.py#L197
> 
> 
> https://github.com/cosmo-epfl/scikit-cosmo/blob/43658d3944e491a847ec571891b4b1375daa6d61/skcosmo/linear_model/_ridge.py#L204
> 
> 
> Should be `sum` and not `len`. By using `len` the whole size is used and not only the values which are `True`.
> Simple bug, but it makes the "cutoff" not cutting of any eigenvalues, so no regularization is used except the numerical one due to `rcond` which is very small.
> This influences also the result of reconstruction measures, since this it uses the "cutoff" regularization type.


The test is a bit complicated on first sight. But I think it is a good way to check if a regularized linear model gives reasonable results. It definitely catches the error caused by this bug as I have tried it.