### PR TITLE
Sample selection restructure

### DIFF
--- a/docs/source/selection.rst
+++ b/docs/source/selection.rst
@@ -7,7 +7,7 @@ and Farthest Point Sampling.
 
 In their classical form, these methods determine a data subset that maximizes the
 variance (CUR) or distribution (FPS) of the features or samples. These methods
-can be modified to include  aspects of supervised methods, in a formulation
+can be modified to combine supervised and unsupervised learning, in a formulation
 denoted `PCov-CUR` and `PCov-FPS`.
 For further reading, refer to [Imbalzano2018]_ and [Cersonsky2021]_.
 
@@ -38,6 +38,9 @@ single iteration based upon the relative :math:`\pi` importance.
 These selection methods can be modified to be semi-supervised by using augmented
 right or left singular vectors, as shown in [Cersonsky2021]_.
 
+Feature Selection using CUR
+----------------------------
+
 .. currentmodule:: skcosmo.feature_selection
 .. autoclass:: CUR
     :show-inheritance:
@@ -45,15 +48,33 @@ right or left singular vectors, as shown in [Cersonsky2021]_.
 
     .. automethod:: fit
 
-WARNING
--------
-The following two CUR methods are undergoing re-structuring, and will soon be
-replaced with classes similar in structure to `CUR`.
+Sample Selection using CUR
+----------------------------
+
+.. currentmodule:: skcosmo.sample_selection
+.. autoclass:: CUR
+    :show-inheritance:
+    :no-undoc-members:
+
+    .. automethod:: fit
+
+
+Feature Selection using CUR + PCovR
+-----------------------------------
+
+**WARNING: the following method is currently under development, and will soon
+be replaced by a sklearn-style method named** `skcosmo.feature_selection.PCovCUR`
 
 .. currentmodule:: skcosmo.feature_selection
 .. autoclass:: FeatureCUR
     :show-inheritance:
     :members:
+
+Sample Selection using CUR + PCovR
+----------------------------------
+
+**WARNING: the following method is currently under development, and will soon
+be replaced by a sklearn-style method named** `skcosmo.sample_selection.PCovCUR`
 
 .. currentmodule:: skcosmo.sample_selection
 .. autoclass:: SampleCUR
@@ -72,8 +93,9 @@ In FPS, the selection of the first point is made at random or by a separate metr
 Each subsequent selection is made to maximize the distance to the previous selections.
 It is common to use the Euclidean distance, however other distance metrics may be employed.
 
-These selection methods can be modified to be semi-supervised by using the
-PCovR covariance and Gram matrices to compute the distances, as shown in [Cersonsky2021]_.
+
+Feature Selection using FPS
+---------------------------
 
 .. currentmodule:: skcosmo.feature_selection
 .. autoclass:: FPS
@@ -82,17 +104,35 @@ PCovR covariance and Gram matrices to compute the distances, as shown in [Cerson
 
     .. automethod:: fit
 
+Sample Selection using FPS
+--------------------------
 
-WARNING
--------
-The following two FPS methods are undergoing re-structuring, and will soon be
-replaced with classes similar in structure to `FPS`.
+.. currentmodule:: skcosmo.sample_selection
+.. autoclass:: FPS
+    :show-inheritance:
+    :no-undoc-members:
+
+    .. automethod:: fit
+
+
+Feature Selection using FPS + PCovR
+-----------------------------------
+
+**WARNING: the following method is currently under development, and will soon
+be replaced by a sklearn-style method named** `skcosmo.feature_selection.PCovFPS`
 
 .. currentmodule:: skcosmo.feature_selection
 .. autoclass:: FeatureFPS
     :show-inheritance:
 
     .. automethod:: select
+
+
+Sample Selection using FPS + PCovR
+-----------------------------------
+
+**WARNING: the following method is currently under development, and will soon
+be replaced by a sklearn-style method named** `skcosmo.sample_selection.PCovFPS`
 
 .. currentmodule:: skcosmo.sample_selection
 .. autoclass:: SampleFPS

--- a/skcosmo/sample_selection/__init__.py
+++ b/skcosmo/sample_selection/__init__.py
@@ -5,6 +5,7 @@ with the optional PCov-flavor
 
 from ..selection.FPS import SampleFPS
 from ..selection.CUR import SampleCUR
+from .simple_fps import FPS
+from .simple_cur import CUR
 
-
-__all__ = ["SampleFPS", "SampleCUR"]
+__all__ = ["SampleFPS", "SampleCUR", "CUR", "FPS"]

--- a/skcosmo/sample_selection/_greedy.py
+++ b/skcosmo/sample_selection/_greedy.py
@@ -1,0 +1,293 @@
+"""
+Sequential sample selection
+"""
+import numbers
+import warnings
+
+import numpy as np
+
+from sklearn.feature_selection._base import SelectorMixin
+from sklearn.base import BaseEstimator, MetaEstimatorMixin
+from sklearn.utils.validation import check_is_fitted, check_array
+from skcosmo.utils import get_progress_bar
+
+
+class GreedySelector(SelectorMixin, BaseEstimator, MetaEstimatorMixin):
+    """Transformer that performs Greedy Sample Selection.
+
+    This Greedy Selector adds (forward selection) samples to form a
+    sample subset in a greedy fashion. At each stage, the model scores each
+    sample (without an estimator) and chooses the sample with the maximum score.
+
+    Parameters
+    ----------
+
+    n_samples_to_select : int or float, default=None
+        The number of samples to select. If `None`, half of the samples are
+        selected. If integer, the parameter is the absolute number of samples
+        to select. If float between 0 and 1, it is the fraction of samples to
+        select.
+
+    score_thresh_to_select : float, default=None
+        Threshold for the score. If `None` selection will continue until the
+        number or fraction given by n_samples_to_select is chosen. Otherwise
+        will stop when the score falls below the threshold.
+
+    scoring : str, callable, list/tuple or dict, default=None
+        A single str (see :ref:`scoring_parameter`) or a callable
+        (see :ref:`scoring`) to evaluate the samples. It is assumed that the
+        next sample to select is that which maximizes the score.
+
+        NOTE that when using custom scorers, each scorer should return a single
+        value. Metric functions returning a list/array of values can be wrapped
+        into multiple scorers that return one value each.
+
+    full : boolean
+        In the case that all non-redundant samples are exhausted, choose
+        randomly from the remaining samples.
+
+    progress_bar: boolean, default=False
+                  option to use `tqdm <https://tqdm.github.io/>`_
+                  progress bar to monitor selections
+
+    Attributes
+    ----------
+
+
+    n_samples_to_select : int
+        The number of samples that were selected.
+
+    X_selected_ : ndarray (n_samples_to_select, n_features)
+                  The samples selected
+
+    y_selected_ : ndarray (n_samples_to_select, n_targets)
+              The corresponding targets of the selected samples
+
+    eligible_ : ndarray of shape (n_samples,), dtype=bool
+        A mask of samples eligible for selection
+
+    n_selected_ : int
+        The number of samples that have been selected thus far
+
+    report_progress : callable
+        A wrapper to report the progress of the selector using a `tqdm` style
+        progress bar
+
+    score_threshold : float (optional)
+        A score below which to stop selecting samples
+
+    selected_idx_ : ndarray of integers
+                    indices of the selected samples, with respect to the
+                    original fitted matrix
+
+    support_ : ndarray of shape (samples,), dtype=bool
+        The mask of selected samples.
+
+    """
+
+    def __init__(
+        self,
+        scoring,
+        n_samples_to_select=None,
+        score_thresh_to_select=None,
+        progress_bar=False,
+        full=False,
+    ):
+
+        self.n_samples_to_select = n_samples_to_select
+        self.n_selected_ = 0
+        self.scoring = scoring
+
+        if full and score_thresh_to_select is not None:
+            raise ValueError(
+                "You cannot specify both `score_thresh_to_select` and `full=True`."
+            )
+
+        self.score_threshold = score_thresh_to_select
+        self.full = full
+
+        if progress_bar:
+            self.report_progress = get_progress_bar()
+        else:
+            self.report_progress = lambda x: x
+
+    def fit(self, X, y=None, warm_start=False):
+        """Learn the samples to select.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Training vectors.
+        y : array-like of shape (n_samples,)
+            Target values.
+        warm_start : bool
+            Whether the fit should continue after having already
+            run, after increasing n_samples_to_select.
+            Assumes it is called with the same X and y
+
+        Returns
+        -------
+        self : object
+        """
+        tags = self._get_tags()
+
+        if y is not None:
+            X, y = self._validate_data(
+                X,
+                y,
+                accept_sparse="csc",
+                ensure_min_features=2,
+                force_all_finite=not tags.get("allow_nan", True),
+                multi_output=True,
+            )
+        else:
+            X = check_array(
+                X,
+                accept_sparse="csc",
+                ensure_min_features=2,
+                force_all_finite=not tags.get("allow_nan", True),
+            )
+
+        n_samples = X.shape[0]
+
+        error_msg = (
+            "n_samples_to_select must be either None, an "
+            "integer in [1, n_samples - 1] "
+            "representing the absolute "
+            "number of samples, or a float in (0, 1] "
+            "representing a percentage of samples to "
+            f"select. Got {self.n_samples_to_select} samples and "
+            f"an input with {n_samples} samples."
+        )
+
+        if self.n_samples_to_select is None:
+            n_iterations = n_samples // 2
+        elif isinstance(self.n_samples_to_select, numbers.Integral):
+            if not 0 < self.n_samples_to_select < n_samples:
+                raise ValueError(error_msg)
+            n_iterations = self.n_samples_to_select
+        elif isinstance(self.n_samples_to_select, numbers.Real):
+            if not 0 < self.n_samples_to_select <= 1:
+                raise ValueError(error_msg)
+            n_iterations = int(n_samples * self.n_samples_to_select)
+        else:
+            raise ValueError(error_msg)
+
+        if warm_start:
+            if self.n_selected_ == 0:
+                raise ValueError(
+                    "Cannot fit with warm_start=True without having been previously initialized"
+                )
+            self._continue_greedy_search(X, y, n_iterations)
+        else:
+            self.n_selected_ = 0
+            self._init_greedy_search(X, y, n_iterations)
+
+        n_iterations -= self.n_selected_
+
+        for n in self.report_progress(range(n_iterations)):
+
+            new_sample_idx = self._get_best_new_sample(self.scoring, X, y)
+            if new_sample_idx is not None:
+                self._update_post_selection(X, y, new_sample_idx)
+            else:
+                warnings.warn(
+                    f"Score threshold of {self.score_threshold} reached."
+                    f"Terminating search at {self.n_selected_} / {self.n_samples_to_select}."
+                )
+                self.X_selected_ = self.X_selected_[:n]
+                if hasattr(self, "y_selected_"):
+                    self.y_selected_ = self.y_selected_[:n]
+                self.selected_idx_ = self.selected_idx_[:n]
+                self._postprocess(X, y)
+                return self
+
+        self._postprocess(X, y)
+        return self
+
+    def _init_greedy_search(self, X, y, n_to_select):
+        """ Initializes the search. Prepares an array to store the selected samples. """
+
+        self.eligible_ = np.ones(X.shape[0], dtype=bool)
+
+        self.X_selected_ = np.zeros((n_to_select, X.shape[1]), float)
+        if y is not None:
+            self.y_selected_ = np.zeros(
+                (n_to_select, y.reshape(y.shape[0], -1).shape[1]), float
+            )
+        self.selected_idx_ = np.zeros((n_to_select), int)
+
+    def _continue_greedy_search(self, X, y, n_to_select):
+        """ Continues the search. Prepares an array to store the selected samples. """
+
+        n_pad = n_to_select - self.n_selected_
+
+        self.X_selected_ = np.pad(
+            self.X_selected_,
+            [(0, n_pad), (0, 0)],
+            "constant",
+            constant_values=0.0,
+        )
+
+        if hasattr(self, "y_selected_"):
+            self.y_selected_ = np.pad(
+                self.y_selected_,
+                [(0, n_pad), (0, 0)],
+                "constant",
+                constant_values=0.0,
+            )
+
+        old_idx = self.selected_idx_.copy()
+        self.selected_idx_ = np.zeros((n_to_select), int)
+        self.selected_idx_[: self.n_selected_] = old_idx
+
+    def _get_best_new_sample(self, scorer, X, y):
+
+        scores = scorer(X, y)
+        scores = scores[self.eligible_]
+
+        if self.score_threshold is not None and max(scores) < self.score_threshold:
+            return None
+        else:
+            return np.where(self.eligible_)[0][np.argmax(scores)]
+
+    def _update_post_selection(self, X, y, last_selected):
+        """
+        Saves the most recently selected sample and increments the sample counter
+        """
+
+        self.X_selected_[self.n_selected_] = X[last_selected]
+        if hasattr(self, "y_selected_"):
+            self.y_selected_[self.n_selected_] = y[last_selected]
+        self.selected_idx_[self.n_selected_] = last_selected
+        self.n_selected_ += 1
+        self.eligible_[last_selected] = False
+
+    def _get_support_mask(self):
+        check_is_fitted(self, ["support_"])
+        return self.support_
+
+    def _postprocess(self, X, y):
+        """ Post-process X and / or y when selection is finished """
+        self.support_ = ~self.eligible_
+
+    def _more_tags(self):
+        return {
+            "requires_y": False,
+        }
+
+    def transform(self, X):
+        """
+        Returns the selected samples from a given dataset
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Full set of samples to select from
+
+        Returns
+        -------
+        X_selected : array of shape(n_selected_samples, n_features)
+            Selected samples
+        """
+        return X[self._get_support_mask()]

--- a/skcosmo/sample_selection/simple_cur.py
+++ b/skcosmo/sample_selection/simple_cur.py
@@ -1,0 +1,214 @@
+import numpy as np
+
+from sklearn.utils import check_random_state
+from sklearn.utils.extmath import randomized_svd
+
+from ._greedy import GreedySelector
+from ..utils import X_orthogonalizer, Y_sample_orthogonalizer
+
+
+class CUR(GreedySelector):
+    """Transformer that performs Greedy Feature Selection using by choosing samples
+    which maximize the magnitude of the left singular vectors, consistent with
+    classic CUR matrix decomposition.
+
+    Parameters
+    ----------
+
+    n_samples_to_select : int or float, default=None
+        The number of samples to select. If `None`, half of the samples are
+        selected. If integer, the parameter is the absolute number of samples
+        to select. If float between 0 and 1, it is the fraction of samples to
+        select.
+
+    score_thresh_to_select : float, default=None
+        Threshold for the score. If `None` selection will continue until the
+        number or fraction given by n_samples_to_select is chosen. Otherwise
+        will stop when the score falls below the threshold.
+
+    iterative : boolean
+                whether to orthogonalize after each selection, defaults to `true`
+
+    k : int
+        number of eigenvectors to compute the importance score with, defaults to 1
+
+    tolerance: float
+         threshold below which scores will be considered 0, defaults to 1E-12
+
+    iterated_power : int or 'auto', default='auto'
+         Number of iterations for the power method computed by
+         svd_solver == 'randomized'.
+         Must be of range [0, infinity).
+
+    random_state : int, RandomState instance or None, default=None
+         Pass an int for reproducible results across multiple function calls.
+
+    progress_bar: boolean, default=False
+                  option to use `tqdm <https://tqdm.github.io/>`_
+                  progress bar to monitor selections
+
+    Attributes
+    ----------
+
+    n_samples_to_select : int
+        The number of samples that were selected.
+
+    X_selected_ : ndarray (n_samples_to_select, n_features)
+                  The samples selected
+
+    y_selected_ : ndarray (n_samples_to_select, n_properties)
+                  The corresponding target values for the samples selected
+
+    X_current_ : ndarray (n_samples, n_features)
+                  The samples, orthogonalized by previously selected samples
+
+    y_current_ : ndarray (n_samples, n_properties)
+                The properties, if supplied, orthogonalized by a regression on
+                the previously selected samples
+
+    eligible_ : ndarray of shape (n_samples,), dtype=bool
+                A mask of samples eligible for selection
+
+    n_selected_ : int
+                The number of samples that have been selected thus far
+
+    report_progress : callable
+                A wrapper to report the progress of the selector using a `tqdm` style
+                progress bar
+
+    score_threshold : float (optional)
+                A score below which to stop selecting samples
+
+    selected_idx_ : ndarray of integers
+                    indices of the selected samples, with respect to the
+                    original fitted matrix
+
+    support_ : ndarray of shape (n_samples,), dtype=bool
+        The mask of selected samples.
+
+    """
+
+    def __init__(
+        self,
+        n_samples_to_select=None,
+        score_thresh_to_select=None,
+        iterative=True,
+        k=1,
+        tolerance=1e-12,
+        iterated_power="auto",
+        random_state=None,
+        progress_bar=False,
+    ):
+
+        scoring = self.score
+        self.k = k
+        self.iterative = iterative
+        self.iterated_power = iterated_power
+        self.random_state = random_state
+
+        super().__init__(
+            scoring=scoring,
+            n_samples_to_select=n_samples_to_select,
+            progress_bar=progress_bar,
+            score_thresh_to_select=tolerance,
+        )
+
+    def _init_greedy_search(self, X, y, n_to_select):
+        """
+        Initializes the search. Prepares an array to store the selected
+        samples and computes their initial importance score.
+        """
+
+        self.X_current = X.copy()
+        if y is not None:
+            self.y_current = y.copy()
+        else:
+            self.y_current = None
+
+        self.pi_ = self._compute_pi(self.X_current, self.y_current)
+
+        super()._init_greedy_search(X, y, n_to_select)
+
+    def _continue_greedy_search(self, X, y, n_to_select):
+        """
+        Continues the search. Prepares an array to store the selected
+        samples, orthogonalizes the samples by those already selected,
+        and computes their initial importance.
+        """
+
+        self.X_current = X_orthogonalizer(X.T, x2=self.X_selected_.T).T
+        if self.y_current is not None:
+            self.y_current = Y_sample_orthogonalizer(
+                self.y_current,
+                self.X_current,
+                y_ref=self.y_selected_,
+                X_ref=self.X_selected_,
+                tol=1e-12,
+            )
+        self.pi_ = self._compute_pi(self.X_current, self.y_current)
+        super()._continue_greedy_search(X, y, n_to_select)
+
+    def score(self, X, y):
+        """
+        Returns the current importance of all samples
+        """
+
+        return self.pi_
+
+    def _compute_pi(self, X, y=None):
+        """
+        For sample selection, the importance score :math:`\\pi` is the sum over
+        the squares of the first :math:`k` components of the right singular vectors
+
+        .. math::
+
+            \\pi_j =
+            \\sum_i^k \\left(\\mathbf{U}_\\mathbf{\\tilde{C}}\\right)_{ij}^2.
+
+        where :math:`{\\mathbf{C} = \\mathbf{X}^T\\mathbf{X}.
+        """
+
+        random_state = check_random_state(self.random_state)
+
+        # sign flipping is done inside
+        U, _, _ = randomized_svd(
+            X,
+            n_components=self.k,
+            n_iter=self.iterated_power,
+            flip_sign=True,
+            random_state=random_state,
+        )
+        new_pi = (np.real(U[:, : self.k]) ** 2.0).sum(axis=1)
+        return new_pi
+
+    def _update_post_selection(self, X, y, last_selected):
+        """
+        Saves the most recently selected sample, increments the sample counter,
+        and, if the CUR is iterative, orthogonalizes the remaining samples by
+        the most recently selected.
+        """
+        super()._update_post_selection(X, y, last_selected)
+
+        if self.iterative:
+            if self.y_current is not None:
+                self.y_current = Y_sample_orthogonalizer(
+                    self.y_current,
+                    self.X_current,
+                    y_ref=self.y_selected_,
+                    X_ref=self.X_selected_,
+                    tol=1e-12,
+                )
+            self.X_current = X_orthogonalizer(
+                x1=self.X_current.T, c=last_selected, tol=1e-12
+            ).T
+
+            if self.y_current is not None:
+                self.pi_[self.eligible_] = self._compute_pi(
+                    self.X_current[self.eligible_], self.y_current[self.eligible_]
+                )
+            else:
+                self.pi_[self.eligible_] = self._compute_pi(
+                    self.X_current[self.eligible_], self.y_current
+                )
+
+        self.pi_[last_selected] = 0.0

--- a/skcosmo/sample_selection/simple_fps.py
+++ b/skcosmo/sample_selection/simple_fps.py
@@ -1,0 +1,155 @@
+import numpy as np
+import numbers
+
+from sklearn.utils.validation import NotFittedError
+from ._greedy import GreedySelector
+
+
+class FPS(GreedySelector):
+    """Transformer that performs Greedy Feature Selection using Farthest Point Sampling.
+
+
+    Parameters
+    ----------
+
+    n_samples_to_select : int or float, default=None
+        The number of samples to select. If `None`, half of the samples are
+        selected. If integer, the parameter is the absolute number of samples
+        to select. If float between 0 and 1, it is the fraction of samples to
+        select.
+
+    initialize: int or 'random', default=0
+        Index of the first sample to be selected. If 'random', picks a random
+        value when fit starts.
+
+    progress_bar: boolean, default=False
+                  option to use `tqdm <https://tqdm.github.io/>`_
+                  progress bar to monitor selections
+
+    tolerance: float, defaults to 1E-12
+                threshold below which distances will be considered 0
+
+    Attributes
+    ----------
+    haussdorf_ : ndarray of shape (n_samples,)
+                 the minimum distance from each sample to the set of selected
+                 samples. once a sample is selected, the distance is not updated;
+                 the final list will reflect the distances when selected.
+    n_samples_to_select : int
+        The number of samples that were selected.
+
+    norms_ : ndarray of shape (n_samples,)
+        The self-covariances of each of the samples
+
+    X_selected_ : ndarray (n_samples_to_select, n_features)
+                  The samples selected
+
+    y_selected_ : ndarray (n_samples_to_select, n_properties)
+                  The corresponding target values for the samples selected
+
+    eligible_ : ndarray of shape (n_samples,), dtype=bool
+                A mask of samples eligible for selection
+
+    n_selected_ : int
+                The number of samples that have been selected thus far
+
+    report_progress : callable
+                A wrapper to report the progress of the selector using a `tqdm` style
+                progress bar
+
+    score_threshold : float (optional)
+                A score below which to stop selecting samples
+
+    selected_idx_ : ndarray of integers
+                    indices of the selected samples, with respect to the
+                    original fitted matrix
+
+    support_ : ndarray of shape (n_samples,), dtype=bool
+        The mask of selected samples.
+
+    """
+
+    def __init__(
+        self,
+        n_samples_to_select=None,
+        initialize=0,
+        tolerance=1e-12,
+        progress_bar=False,
+    ):
+
+        scoring = self.score
+        self.initialize = initialize
+
+        super().__init__(
+            scoring=scoring,
+            n_samples_to_select=n_samples_to_select,
+            progress_bar=progress_bar,
+            score_thresh_to_select=tolerance,
+        )
+
+    def _calculate_distances(self, X, last_selected):
+        return self.norms_ + self.norms_[last_selected] - 2 * X[last_selected] @ X.T
+
+    def _set_norms(self, X, y):
+        self.norms_ = (X ** 2).sum(axis=1)
+
+    def _init_greedy_search(self, X, y, n_to_select):
+        """
+        Initializes the search. Prepares an array to store the selected
+        samples, selects the initial sample (unless provided), and
+        computes the starting haussdorf distances.
+        """
+
+        super()._init_greedy_search(X, y, n_to_select)
+        self._set_norms(X, y)
+
+        if self.initialize == "random":
+            initialize = np.random.randint(X.shape[0])
+        elif isinstance(self.initialize, numbers.Integral):
+            initialize = self.initialize
+        else:
+            raise ValueError("Invalid value of the initialize parameter")
+
+        self.selected_idx_[0] = initialize
+        self.haussdorf_ = np.full(X.shape[0], np.inf)
+        self.haussdorf_at_select_ = np.full(X.shape[0], np.inf)
+        self._update_post_selection(X, y, self.selected_idx_[0])
+
+    def score(self, X, y=None):
+        """
+        Returns the Haussdorf distances of all samples to previous selections
+
+        Parameters
+        ----------
+        X : ignored
+        y : ignored
+
+        Returns
+        -------
+        haussdorf : Haussdorf distances
+        """
+        return self.haussdorf_
+
+    def _update_post_selection(self, X, y, last_selected):
+        """
+        Saves the most recently selected sample, increments the sample counter,
+        and, recomputes haussdorf distances.
+        """
+
+        self.haussdorf_at_select_[last_selected] = self.haussdorf_[last_selected]
+        self.haussdorf_[last_selected] = 0
+
+        # distances of all points to the new point
+        new_dist = self._calculate_distances(X, last_selected)
+
+        # update in-place the Haussdorf distance list
+        np.minimum(self.haussdorf_, new_dist, self.haussdorf_)
+
+        super()._update_post_selection(X, y, last_selected)
+
+    def get_select_distance(self):
+        """ Returns the Haussdorf distances of selecte samples at their time of selection"""
+        if hasattr(self, "haussdorf_at_select_"):
+            return self.haussdorf_at_select_[self.selected_idx_]
+        else:
+            raise NotFittedError()

--- a/skcosmo/utils/__init__.py
+++ b/skcosmo/utils/__init__.py
@@ -5,12 +5,17 @@ used by multiple packages
 
 from .progress_bar import get_progress_bar
 from .pcovr_utils import pcovr_covariance, pcovr_kernel
-from .orthogonalizers import feature_orthogonalizer, sample_orthogonalizer
+from .orthogonalizers import (
+    X_orthogonalizer,
+    Y_sample_orthogonalizer,
+    Y_feature_orthogonalizer,
+)
 
 __all__ = [
     "get_progress_bar",
     "pcovr_covariance",
     "pcovr_kernel",
-    "feature_orthogonalizer",
-    "sample_orthogonalizer",
+    "X_orthogonalizer",
+    "Y_sample_orthogonalizer",
+    "Y_feature_orthogonalizer",
 ]

--- a/tests/test_greedy_sample_selector.py
+++ b/tests/test_greedy_sample_selector.py
@@ -1,0 +1,160 @@
+import unittest
+import numpy as np
+
+from sklearn.datasets import load_boston
+from sklearn import exceptions
+from sklearn.exceptions import NotFittedError
+
+from skcosmo.sample_selection._greedy import GreedySelector
+
+
+class GreedyTester(GreedySelector):
+    def __init__(self, n_samples_to_select=None, score_thresh_to_select=None, **kwargs):
+        super().__init__(
+            scoring=self.score,
+            n_samples_to_select=n_samples_to_select,
+            score_thresh_to_select=score_thresh_to_select,
+            **kwargs,
+        )
+
+    def score(self, X, y=None):
+        scores = np.linalg.norm(X, axis=1)
+        scores[self.selected_idx_] = 0.0
+        return scores
+
+
+class TestGreedy(unittest.TestCase):
+    def setUp(self):
+        self.X, self.y = load_boston(return_X_y=True)
+
+    def test_restart(self):
+        """ tests that restart does not crash """
+        selector = GreedyTester(n_samples_to_select=2)
+        selector.fit(self.X, self.y)
+        self.assertEqual(len(selector.selected_idx_), 2)
+
+        selector.n_samples_to_select = 5
+        selector.fit(self.X, self.y, warm_start=True)
+        self.assertEqual(len(selector.selected_idx_), 5)
+
+    def test_restart_with_y(self):
+        """ tests that restart with y does not crash """
+        selector = GreedyTester(n_samples_to_select=2)
+        selector.fit(self.X, None)
+        self.assertEqual(len(selector.selected_idx_), 2)
+
+        selector.n_samples_to_select = 5
+        selector.fit(self.X, None, warm_start=True)
+        self.assertEqual(len(selector.selected_idx_), 5)
+
+    def test_score_threshold(self):
+        selector = GreedyTester(score_thresh_to_select=600, n_samples_to_select=400)
+        with self.assertWarns(
+            Warning,
+            msg="Score threshold of 600 reached. Terminating search at 139 / 400.",
+        ):
+            selector.fit(self.X)
+
+    def test_score_threshold_with_y(self):
+        selector = GreedyTester(score_thresh_to_select=600, n_samples_to_select=400)
+        with self.assertWarns(
+            Warning,
+            msg="Score threshold of 600 reached. Terminating search at 139 / 400.",
+        ):
+            selector.fit(self.X, self.y)
+
+    def test_score_threshold_and_full(self):
+        with self.assertRaises(ValueError) as cm:
+            _ = GreedyTester(
+                score_thresh_to_select=20, full=True, n_samples_to_select=12
+            )
+            self.assertEqual(
+                str(cm.message),
+                "You cannot specify both `score_thresh_to_select` and `full=True`.",
+            )
+
+    def test_bad_warm_start(self):
+        selector = GreedyTester()
+        with self.assertRaises(ValueError) as cm:
+            selector.fit(self.X, warm_start=True)
+            self.assertTrue(
+                str(cm.message),
+                "Cannot fit with warm_start=True without having been previously initialized",
+            )
+
+    def test_good_y(self):
+        selector = GreedyTester(n_samples_to_select=2)
+        selector.fit(X=self.X, y=self.y)
+        y_s = selector.transform(self.y)
+        self.assertEqual(selector.y_selected_.shape[0], 2)
+        self.assertEqual(y_s.shape[0], 2)
+
+    def test_bad_y(self):
+        selector = GreedyTester(n_samples_to_select=2)
+        with self.assertRaises(ValueError):
+            selector.fit(X=self.X, y=self.y[:2])
+
+    def test_bad_transform(self):
+        selector = GreedyTester(n_samples_to_select=2)
+        with self.assertRaises(exceptions.NotFittedError):
+            _ = selector.transform(self.X)
+
+    def test_no_nsamples(self):
+        selector = GreedyTester()
+        selector.fit(self.X)
+        self.assertEqual(len(selector.selected_idx_), self.X.shape[0] // 2)
+
+    def test_decimal_nsamples(self):
+        selector = GreedyTester(n_samples_to_select=0.2)
+        selector.fit(self.X)
+        self.assertEqual(len(selector.selected_idx_), int(self.X.shape[0] * 0.2))
+
+    def test_bad_nsamples(self):
+        for nf in [1.2, "1", 2000]:
+            with self.subTest(n_samples=nf):
+                selector = GreedyTester(n_samples_to_select=nf)
+                with self.assertRaises(ValueError) as cm:
+                    selector.fit(self.X)
+                    self.assertEqual(
+                        str(cm.message),
+                        (
+                            "n_samples_to_select must be either None, an "
+                            "integer in [1, n_samples - 1] "
+                            "representing the absolute "
+                            "number of samples, or a float in (0, 1] "
+                            "representing a percentage of samples to "
+                            f"select. Got {nf}"
+                        ),
+                    )
+
+    def test_not_fitted(self):
+        with self.assertRaises(NotFittedError):
+            selector = GreedyTester()
+            _ = selector._get_support_mask()
+
+    def test_fitted(self):
+        selector = GreedyTester()
+        selector.fit(self.X)
+        _ = selector._get_support_mask()
+
+    def test_no_tqdm(self):
+        """
+        This test checks that the selector cannot use a progress bar when tqdm
+        is not installed
+        """
+        import sys
+
+        sys.modules["tqdm"] = None
+
+        with self.assertRaises(ImportError) as cm:
+            _ = GreedyTester(progress_bar=True)
+            self.assertEqual(
+                str(cm.exception),
+                "tqdm must be installed to use a progress bar."
+                "Either install tqdm or re-run with"
+                "progress_bar = False",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_simple_sample_cur.py
+++ b/tests/test_simple_sample_cur.py
@@ -1,0 +1,73 @@
+import unittest
+import numpy as np
+
+from sklearn.datasets import load_boston
+from sklearn import exceptions
+
+from skcosmo.sample_selection import CUR
+
+
+class TestCUR(unittest.TestCase):
+    def setUp(self):
+        self.X, self.y = load_boston(return_X_y=True)
+        self.idx = [488, 450, 183, 199, 380, 483, 214, 126, 374, 8]
+
+    def test_bad_y(self):
+        selector = CUR(n_samples_to_select=2)
+        with self.assertRaises(ValueError):
+            selector.fit(X=self.X, y=self.y[:2])
+
+    def test_good_y(self):
+        selector = CUR(n_samples_to_select=2)
+        selector.fit(X=self.X, y=self.y)
+        self.assertTrue(selector.y_current is not None)
+
+    def test_no_y(self):
+        selector = CUR(n_samples_to_select=2)
+        selector.fit(X=self.X, y=None)
+        self.assertTrue(selector.y_current is None)
+
+    def test_bad_transform(self):
+        selector = CUR(n_samples_to_select=2)
+        with self.assertRaises(exceptions.NotFittedError):
+            _ = selector.transform(self.X)
+
+    def test_restart(self):
+        """
+        This test checks that the model can be restarted with a new instance
+        """
+
+        selector = CUR(n_samples_to_select=1)
+        selector.fit(self.X)
+
+        for i in range(len(self.idx) - 2):
+            selector.n_samples_to_select += 1
+            selector.fit(self.X, warm_start=True)
+            self.assertEqual(selector.selected_idx_[i], self.idx[i])
+
+    def test_restart_with_y(self):
+        """
+        This test checks that the model can be restarted with a new instance
+        """
+
+        selector = CUR(n_samples_to_select=1)
+        selector.fit(self.X, self.y)
+
+        for i in range(len(self.idx) - 2):
+            selector.n_samples_to_select += 1
+            selector.fit(self.X, self.y, warm_start=True)
+            self.assertEqual(selector.selected_idx_[i], self.idx[i])
+
+    def test_non_it(self):
+        """
+        This test checks that the model can be run non-iteratively
+        """
+        self.idx = [488, 492, 491, 489, 398, 374, 373, 386, 400, 383]
+        selector = CUR(n_samples_to_select=len(self.idx), iterative=False)
+        selector.fit(self.X)
+
+        self.assertTrue(np.allclose(selector.selected_idx_, self.idx))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_simple_sample_fps.py
+++ b/tests/test_simple_sample_fps.py
@@ -1,0 +1,60 @@
+import unittest
+
+from sklearn.datasets import load_boston
+from sklearn.utils.validation import NotFittedError
+
+from skcosmo.sample_selection import FPS
+
+
+class TestFPS(unittest.TestCase):
+    def setUp(self):
+        self.X, _ = load_boston(return_X_y=True)
+        self.idx = [0, 410, 492, 102, 134, 413, 54, 32, 353, 126]
+
+    def test_restart(self):
+        """
+        This test checks that the model can be restarted with a new number of
+        samples and `warm_start`
+        """
+
+        selector = FPS(n_samples_to_select=1, initialize=self.idx[0])
+        selector.fit(self.X)
+
+        for i in range(2, len(self.idx)):
+            selector.n_samples_to_select = i
+            selector.fit(self.X, warm_start=True)
+            self.assertEqual(selector.selected_idx_[i - 1], self.idx[i - 1])
+
+    def test_initialize(self):
+        """
+        This test checks that the model can be initialized in all applicable manners
+        and throws an error otherwise
+        """
+
+        for initialize in [self.idx[0], "random"]:
+            with self.subTest(initialize=initialize):
+                selector = FPS(n_samples_to_select=1, initialize=initialize)
+                selector.fit(self.X)
+
+        with self.assertRaises(ValueError) as cm:
+            selector = FPS(n_samples_to_select=1, initialize="bad")
+            selector.fit(self.X)
+            self.assertEquals(
+                str(cm.message), "Invalid value of the initialize parameter"
+            )
+
+    def test_get_distances(self):
+        """
+        This test checks that the haussdorf distances are returnable after fitting
+        """
+        selector = FPS(n_samples_to_select=1)
+        selector.fit(self.X)
+        _ = selector.get_select_distance()
+
+        with self.assertRaises(NotFittedError):
+            selector = FPS(n_samples_to_select=1)
+            _ = selector.get_select_distance()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Adding analogous simple selectors for sample selection. _greedy, simple_cur, and simple_fps are identical to their counterparts within feature_selection, with the few caveats:

- add variables and methods named with `feature` have been replaced with `sample`
- whenever a sample from X is stored and y is present, the analogous sample in y is stored
- ditto with orthogonalization / manipulation
- distances and importance scores are now done with respect to the rows of the matrices
- all indices are stored with respect to rows
- orthogonalizers have been re-written for modularity and clarity (all changes to selection/CUR and related files are due to this change)

This will be in draft mode until #58 is merged.