### PR TITLE
Make PCovR P matrices depend on Y instead of Yhat

### DIFF
--- a/skcosmo/decomposition/pcovr.py
+++ b/skcosmo/decomposition/pcovr.py
@@ -299,7 +299,7 @@ class PCovR(_BasePCA, LinearModel):
                 self.space = "sample"
 
         if self.space == "feature":
-            self._fit_feature_space(X, Y.reshape(Yhat.shape), Yhat, W)
+            self._fit_feature_space(X, Y.reshape(Yhat.shape), Yhat)
         else:
             self._fit_sample_space(X, Y.reshape(Yhat.shape), Yhat, W)
 
@@ -315,7 +315,7 @@ class PCovR(_BasePCA, LinearModel):
         self.components_ = self.pxt_.T  # for sklearn compatibility
         return self
 
-    def _fit_feature_space(self, X, Y, Yhat, W=None):
+    def _fit_feature_space(self, X, Y, Yhat):
         r"""
         In feature-space PCovR, the projectors are determined by:
 

--- a/skcosmo/decomposition/pcovr.py
+++ b/skcosmo/decomposition/pcovr.py
@@ -432,7 +432,7 @@ class PCovR(_BasePCA, LinearModel):
             self.explained_variance_ / self.explained_variance_.sum()
         )
 
-        P = (self.mixing * X.T) + (1.0 - self.mixing) * np.dot(W, Yhat.T)
+        P = (self.mixing * X.T) + (1.0 - self.mixing) * W @ Yhat.T
         T = Vt.T @ np.diagflat(1 / np.sqrt(S))
 
         self.pxt_ = P @ T

--- a/skcosmo/decomposition/pcovr.py
+++ b/skcosmo/decomposition/pcovr.py
@@ -299,9 +299,9 @@ class PCovR(_BasePCA, LinearModel):
                 self.space = "sample"
 
         if self.space == "feature":
-            self._fit_feature_space(X, Yhat, W)
+            self._fit_feature_space(X, Y, Yhat, W)
         else:
-            self._fit_sample_space(X, Yhat, W)
+            self._fit_sample_space(X, Y, Yhat, W)
 
         self.pxy_ = self.pxt_ @ self.pty_
         if len(Y.shape) == 1:
@@ -315,7 +315,7 @@ class PCovR(_BasePCA, LinearModel):
         self.components_ = self.pxt_.T  # for sklearn compatibility
         return self
 
-    def _fit_feature_space(self, X, Yhat, W=None):
+    def _fit_feature_space(self, X, Y, Yhat, W=None):
         r"""
         In feature-space PCovR, the projectors are determined by:
 
@@ -383,9 +383,9 @@ class PCovR(_BasePCA, LinearModel):
         S_inv = np.linalg.pinv(np.diagflat(S[: self.n_components]))
         self.pxt_ = np.linalg.multi_dot([iCsqrt, Vt.T, np.diagflat(S)])
         self.ptx_ = np.linalg.multi_dot([S_inv, Vt, Csqrt])
-        self.pty_ = np.linalg.multi_dot([S_inv, Vt, iCsqrt, X.T, Yhat])
+        self.pty_ = np.linalg.multi_dot([S_inv, Vt, iCsqrt, X.T, Y])
 
-    def _fit_sample_space(self, X, Yhat, W):
+    def _fit_sample_space(self, X, Y, Yhat, W):
         r"""
         In sample-space PCovR, the projectors are determined by:
 
@@ -436,7 +436,7 @@ class PCovR(_BasePCA, LinearModel):
         T = Vt.T @ np.diagflat(1 / np.sqrt(S))
 
         self.pxt_ = P @ T
-        self.pty_ = T.T @ Yhat
+        self.pty_ = T.T @ Y
         self.ptx_ = T.T @ X
 
     def _decompose_truncated(self, mat):

--- a/skcosmo/decomposition/pcovr.py
+++ b/skcosmo/decomposition/pcovr.py
@@ -380,7 +380,9 @@ class PCovR(_BasePCA, LinearModel):
             self.explained_variance_ / self.explained_variance_.sum()
         )
 
-        S_inv = np.array([1.0 / s if s > self.tol else 0.0 for s in S[:self.n_components]])
+        S_inv = np.array(
+            [1.0 / s if s > self.tol else 0.0 for s in S[: self.n_components]]
+        )
         self.pxt_ = np.linalg.multi_dot([iCsqrt, Vt.T, np.diagflat(S)])
         self.ptx_ = np.linalg.multi_dot([S_inv, Vt, Csqrt])
         self.pty_ = np.linalg.multi_dot([S_inv, Vt, iCsqrt, X.T, Y])

--- a/skcosmo/decomposition/pcovr.py
+++ b/skcosmo/decomposition/pcovr.py
@@ -380,9 +380,7 @@ class PCovR(_BasePCA, LinearModel):
             self.explained_variance_ / self.explained_variance_.sum()
         )
 
-        S_inv = np.diagflat(
-            [1.0 / s if s > self.tol else 0.0 for s in S]
-        )
+        S_inv = np.diagflat([1.0 / s if s > self.tol else 0.0 for s in S])
         self.pxt_ = np.linalg.multi_dot([iCsqrt, Vt.T, np.diagflat(S)])
         self.ptx_ = np.linalg.multi_dot([S_inv, Vt, Csqrt])
         self.pty_ = np.linalg.multi_dot([S_inv, Vt, iCsqrt, X.T, Y])

--- a/skcosmo/decomposition/pcovr.py
+++ b/skcosmo/decomposition/pcovr.py
@@ -380,8 +380,8 @@ class PCovR(_BasePCA, LinearModel):
             self.explained_variance_ / self.explained_variance_.sum()
         )
 
-        S_inv = np.array(
-            [1.0 / s if s > self.tol else 0.0 for s in S[: self.n_components]]
+        S_inv = np.diagflat(
+            [1.0 / s if s > self.tol else 0.0 for s in S]
         )
         self.pxt_ = np.linalg.multi_dot([iCsqrt, Vt.T, np.diagflat(S)])
         self.ptx_ = np.linalg.multi_dot([S_inv, Vt, Csqrt])

--- a/skcosmo/decomposition/pcovr.py
+++ b/skcosmo/decomposition/pcovr.py
@@ -299,9 +299,9 @@ class PCovR(_BasePCA, LinearModel):
                 self.space = "sample"
 
         if self.space == "feature":
-            self._fit_feature_space(X, Y, Yhat, W)
+            self._fit_feature_space(X, Y.reshape(Yhat.shape), Yhat, W)
         else:
-            self._fit_sample_space(X, Y, Yhat, W)
+            self._fit_sample_space(X, Y.reshape(Yhat.shape), Yhat, W)
 
         self.pxy_ = self.pxt_ @ self.pty_
         if len(Y.shape) == 1:

--- a/skcosmo/decomposition/pcovr.py
+++ b/skcosmo/decomposition/pcovr.py
@@ -380,7 +380,7 @@ class PCovR(_BasePCA, LinearModel):
             self.explained_variance_ / self.explained_variance_.sum()
         )
 
-        S_inv = np.linalg.pinv(np.diagflat(S[: self.n_components]))
+        S_inv = np.array([1.0 / s if s > self.tol else 0.0 for s in S[:self.n_components])
         self.pxt_ = np.linalg.multi_dot([iCsqrt, Vt.T, np.diagflat(S)])
         self.ptx_ = np.linalg.multi_dot([S_inv, Vt, Csqrt])
         self.pty_ = np.linalg.multi_dot([S_inv, Vt, iCsqrt, X.T, Y])

--- a/skcosmo/decomposition/pcovr.py
+++ b/skcosmo/decomposition/pcovr.py
@@ -380,7 +380,7 @@ class PCovR(_BasePCA, LinearModel):
             self.explained_variance_ / self.explained_variance_.sum()
         )
 
-        S_inv = np.array([1.0 / s if s > self.tol else 0.0 for s in S[:self.n_components])
+        S_inv = np.array([1.0 / s if s > self.tol else 0.0 for s in S[:self.n_components]])
         self.pxt_ = np.linalg.multi_dot([iCsqrt, Vt.T, np.diagflat(S)])
         self.ptx_ = np.linalg.multi_dot([S_inv, Vt, Csqrt])
         self.pty_ = np.linalg.multi_dot([S_inv, Vt, iCsqrt, X.T, Y])

--- a/tests/test_pcovr.py
+++ b/tests/test_pcovr.py
@@ -46,7 +46,7 @@ class PCovRErrorTest(PCovRBaseTest):
         for space in ["feature", "sample", "auto"]:
             with self.subTest(space=space):
                 pcovr = self.model(
-                    mixing=0.0, n_components=self.X.shape[-1], space=space
+                    mixing=0.0, n_components=1, space=space
                 )
 
                 pcovr.estimator.fit(self.X, self.Y)

--- a/tests/test_pcovr.py
+++ b/tests/test_pcovr.py
@@ -45,9 +45,7 @@ class PCovRErrorTest(PCovRBaseTest):
         """
         for space in ["feature", "sample", "auto"]:
             with self.subTest(space=space):
-                pcovr = self.model(
-                    mixing=0.0, n_components=1, space=space
-                )
+                pcovr = self.model(mixing=0.0, n_components=1, space=space)
 
                 pcovr.estimator.fit(self.X, self.Y)
                 Yhat = pcovr.estimator.predict(self.X)


### PR DESCRIPTION
The `self.pty_` matrices should depend on `Y` instead of `Yhat`. While in theory these should be similar, we currently give the user the ability to provide their own regression results -- if the user passes results from a poor regression, `Y` and `Yhat` could be rather different and thus give a "wrong" PCovR projection.

To be merged after #69