### PR TITLE
Update documented defaults in (K)PCovR to match the code

### DIFF
--- a/skcosmo/decomposition/kpcovr.py
+++ b/skcosmo/decomposition/kpcovr.py
@@ -41,7 +41,7 @@ class KPCovR(_BasePCA, LinearModel):
 
     Parameters
     ----------
-    mixing: float, defaults to 0
+    mixing: float, defaults to 0.5
         mixing parameter, as described in PCovR as :math:`{\\alpha}`
 
     n_components: int, float or str, default=None
@@ -118,7 +118,7 @@ class KPCovR(_BasePCA, LinearModel):
     Attributes
     ----------
 
-    mixing: float, defaults to 0
+    mixing: float, defaults to 0.5
         mixing parameter, as described in PCovR as :math:`{\\alpha}`
 
     alpha: float, default=1E-6
@@ -189,7 +189,7 @@ class KPCovR(_BasePCA, LinearModel):
 
     def __init__(
         self,
-        mixing=0.0,
+        mixing=0.5,
         n_components=None,
         svd_solver="auto",
         kernel="linear",

--- a/skcosmo/decomposition/kpcovr.py
+++ b/skcosmo/decomposition/kpcovr.py
@@ -41,7 +41,7 @@ class KPCovR(_BasePCA, LinearModel):
 
     Parameters
     ----------
-    mixing: float, defaults to 1
+    mixing: float, defaults to 0
         mixing parameter, as described in PCovR as :math:`{\\alpha}`
 
     n_components: int, float or str, default=None
@@ -96,7 +96,7 @@ class KPCovR(_BasePCA, LinearModel):
         Learn the inverse transform for non-precomputed kernels.
         (i.e. learn to find the pre-image of a point)
 
-    tol: float, default=0.0
+    tol: float, default=1e-12
         Tolerance for singular values computed by svd_solver == 'arpack'.
         Must be of range [0.0, infinity).
 
@@ -118,13 +118,13 @@ class KPCovR(_BasePCA, LinearModel):
     Attributes
     ----------
 
-    mixing: float, defaults to 1
+    mixing: float, defaults to 0
         mixing parameter, as described in PCovR as :math:`{\\alpha}`
 
     alpha: float, default=1E-6
             Regularization parameter to use in all regression operations.
 
-    tol: float, default=0.0
+    tol: float, default=1e-12
         Tolerance for singular values computed by svd_solver == 'arpack'.
         Must be of range [0.0, infinity).
 

--- a/skcosmo/decomposition/pcovr.py
+++ b/skcosmo/decomposition/pcovr.py
@@ -68,7 +68,7 @@ class PCovR(_BasePCA, LinearModel):
 
     Parameters
     ----------
-    mixing: float, defaults to 0
+    mixing: float, defaults to 0.5
         mixing parameter, as described in PCovR as :math:`{\alpha}`, here named
         to avoid confusion with regularization parameter `alpha`
 
@@ -125,7 +125,7 @@ class PCovR(_BasePCA, LinearModel):
     Attributes
     ----------
 
-    mixing: float, defaults to 0
+    mixing: float, defaults to 0.5
         mixing parameter, as described in PCovR as :math:`{\alpha}`
 
     alpha: float, default=1E-6
@@ -189,7 +189,7 @@ class PCovR(_BasePCA, LinearModel):
 
     def __init__(
         self,
-        mixing=0.0,
+        mixing=0.5,
         n_components=None,
         svd_solver="auto",
         alpha=None,

--- a/skcosmo/decomposition/pcovr.py
+++ b/skcosmo/decomposition/pcovr.py
@@ -68,7 +68,7 @@ class PCovR(_BasePCA, LinearModel):
 
     Parameters
     ----------
-    mixing: float, defaults to 1
+    mixing: float, defaults to 0
         mixing parameter, as described in PCovR as :math:`{\alpha}`, here named
         to avoid confusion with regularization parameter `alpha`
 
@@ -96,7 +96,7 @@ class PCovR(_BasePCA, LinearModel):
         If randomized :
             run randomized SVD by the method of Halko et al.
 
-    tol : float, default=0.0
+    tol : float, default=1e-12
         Tolerance for singular values computed by svd_solver == 'arpack'.
         Must be of range [0.0, infinity).
 
@@ -125,13 +125,13 @@ class PCovR(_BasePCA, LinearModel):
     Attributes
     ----------
 
-    mixing: float, defaults to 1
+    mixing: float, defaults to 0
         mixing parameter, as described in PCovR as :math:`{\alpha}`
 
     alpha: float, default=1E-6
             Regularization parameter to use in all regression operations.
 
-    tol: float, default=0.0
+    tol: float, default=1e-12
         Tolerance for singular values computed by svd_solver == 'arpack'.
         Must be of range [0.0, infinity).
 


### PR DESCRIPTION
The `__init__` functions default to `mixing=0.0` and `tol=1e-12`.