### PR TITLE
Quick-fix for the eigenvalue problem

### DIFF
--- a/skcosmo/decomposition/pcovr.py
+++ b/skcosmo/decomposition/pcovr.py
@@ -375,7 +375,7 @@ class PCovR(_BasePCA, LinearModel):
             )
 
         self.singular_values_ = np.sqrt(S.copy())
-        self.explained_variance_ = (S ** 2) / (X.shape[0] - 1)
+        self.explained_variance_ = S / (X.shape[0] - 1)
         self.explained_variance_ratio_ = (
             self.explained_variance_ / self.explained_variance_.sum()
         )
@@ -427,7 +427,7 @@ class PCovR(_BasePCA, LinearModel):
             )
 
         self.singular_values_ = np.sqrt(S.copy())
-        self.explained_variance_ = (S ** 2) / (X.shape[0] - 1)
+        self.explained_variance_ = S / (X.shape[0] - 1)
         self.explained_variance_ratio_ = (
             self.explained_variance_ / self.explained_variance_.sum()
         )
@@ -527,7 +527,7 @@ class PCovR(_BasePCA, LinearModel):
         U, Vt = svd_flip(U, Vt)
 
         # Get variance explained by singular values
-        explained_variance_ = (S ** 2) / (self.n_samples - 1)
+        explained_variance_ = S / (self.n_samples - 1)
         total_var = explained_variance_.sum()
         explained_variance_ratio_ = explained_variance_ / total_var
 

--- a/skcosmo/decomposition/pcovr.py
+++ b/skcosmo/decomposition/pcovr.py
@@ -374,7 +374,7 @@ class PCovR(_BasePCA, LinearModel):
                 "Unrecognized svd_solver='{0}'" "".format(self._fit_svd_solver)
             )
 
-        self.singular_values_ = S.copy()
+        self.singular_values_ = np.sqrt(S.copy())
         self.explained_variance_ = (S ** 2) / (X.shape[0] - 1)
         self.explained_variance_ratio_ = (
             self.explained_variance_ / self.explained_variance_.sum()
@@ -426,7 +426,7 @@ class PCovR(_BasePCA, LinearModel):
                 "Unrecognized svd_solver='{0}'" "".format(self._fit_svd_solver)
             )
 
-        self.singular_values_ = S.copy()
+        self.singular_values_ = np.sqrt(S.copy())
         self.explained_variance_ = (S ** 2) / (X.shape[0] - 1)
         self.explained_variance_ratio_ = (
             self.explained_variance_ / self.explained_variance_.sum()


### PR DESCRIPTION
The explained variance and singular values were determined by the svd of C or K, not X, and therefore do not need to be squared. The accompanying test will check that all fit parameters of PCovR correspond to those in PCA when mixing = 1.0, as this would've caught this error.