### PR TITLE
Removed usage of randomized_svd

### DIFF
--- a/skcosmo/sample_selection/simple_cur.py
+++ b/skcosmo/sample_selection/simple_cur.py
@@ -1,7 +1,5 @@
 import numpy as np
-
-from sklearn.utils import check_random_state
-from sklearn.utils.extmath import randomized_svd
+import scipy
 
 from ._greedy import GreedySelector
 from ..utils import X_orthogonalizer, Y_sample_orthogonalizer
@@ -34,14 +32,6 @@ class CUR(GreedySelector):
 
     tolerance: float
          threshold below which scores will be considered 0, defaults to 1E-12
-
-    iterated_power : int or 'auto', default='auto'
-         Number of iterations for the power method computed by
-         svd_solver == 'randomized'.
-         Must be of range [0, infinity).
-
-    random_state : int, RandomState instance or None, default=None
-         Pass an int for reproducible results across multiple function calls.
 
     progress_bar: boolean, default=False
                   option to use `tqdm <https://tqdm.github.io/>`_
@@ -95,16 +85,12 @@ class CUR(GreedySelector):
         iterative=True,
         k=1,
         tolerance=1e-12,
-        iterated_power="auto",
-        random_state=None,
         progress_bar=False,
     ):
 
         scoring = self.score
         self.k = k
         self.iterative = iterative
-        self.iterated_power = iterated_power
-        self.random_state = random_state
 
         super().__init__(
             scoring=scoring,
@@ -168,15 +154,9 @@ class CUR(GreedySelector):
         where :math:`{\\mathbf{C} = \\mathbf{X}^T\\mathbf{X}.
         """
 
-        random_state = check_random_state(self.random_state)
-
-        # sign flipping is done inside
-        U, _, _ = randomized_svd(
+        U, _, _ = scipy.sparse.linalg.svds(
             X,
-            n_components=self.k,
-            n_iter=self.iterated_power,
-            flip_sign=True,
-            random_state=random_state,
+            k=self.k,
         )
         U = np.real(U)
         new_pi = (U[:, : self.k] ** 2.0).sum(axis=1)

--- a/tests/test_feature_simple_cur.py
+++ b/tests/test_feature_simple_cur.py
@@ -28,13 +28,13 @@ class TestCUR(unittest.TestCase):
         This test checks that the model can be restarted with a new instance
         """
 
-        ref_selector = CUR(n_features_to_select=self.X.shape[-1] - 2).fit(X=self.X)
+        ref_selector = CUR(n_features_to_select=self.X.shape[-1] - 3).fit(X=self.X)
         ref_idx = ref_selector.selected_idx_
 
         selector = CUR(n_features_to_select=1)
         selector.fit(self.X)
 
-        for i in range(self.X.shape[-1] - 2):
+        for i in range(self.X.shape[-1] - 3):
             selector.n_features_to_select += 1
             selector.fit(self.X, warm_start=True)
             self.assertEqual(selector.selected_idx_[i], ref_idx[i])

--- a/tests/test_sample_simple_cur.py
+++ b/tests/test_sample_simple_cur.py
@@ -53,13 +53,13 @@ class TestCUR(unittest.TestCase):
         This test checks that the model can be restarted with a new instance
         """
 
-        ref_selector = CUR(n_samples_to_select=self.X.shape[0] - 2)
+        ref_selector = CUR(n_samples_to_select=self.X.shape[0] - 3)
         ref_idx = ref_selector.fit(self.X, self.y).selected_idx_
 
         selector = CUR(n_samples_to_select=1)
         selector.fit(self.X, self.y)
 
-        for i in range(self.X.shape[0] - 2):
+        for i in range(self.X.shape[0] - 3):
             selector.n_samples_to_select += 1
             selector.fit(self.X, self.y, warm_start=True)
             self.assertEqual(selector.selected_idx_[i], ref_idx[i])


### PR DESCRIPTION
Turns out using randomized_svd leads to some _random_ results in a few cases. Reverting to scipy.sparse.linalg.svds.