### PR TITLE
Enabled nbconvert to skip cells that contain tocs or nothing

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,6 +23,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r docs/requirements.txt
+          pip install .
           sudo apt install pandoc
       - name: Build the documentation
         run: |

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,8 +1,10 @@
 ipykernel
 matplotlib
 nbsphinx
+nbconvert
 numpy
 scikit-learn >=0.24.0
 sphinx >=3.3
 sphinx_rtd_theme
 tqdm
+traitlets


### PR DESCRIPTION
Addressing #79 with a sledgehammer.

In order to solve this, I tried a few approaches and settled on this one. I figured we should take a passive approach to this (aka not have the users / devs have to enable certain behavior, but to have it handled for them). I played around with having a CI documentation fail whenever a toc was found in the compiled notebooks, but this might not transfer well to RTD. I settled on compiling the notebooks using nbconvert (which is the tool nbsphinx employs) using a preprocessing filter for the kinds of cells we don't want to include. _Unfortunately_, nbsphinx doesn't have a direct pathway to set these variables, so I had to turn execution via nbsphinx off. For reference, AFAIK there is no way to enable selective cell hiding in nbsphinx without hard-coding "nbsphinx"="hidden" into certain cells. 