### PR TITLE
[BUG] The problem with sample selection for datasets with 1 attribute. 

### DIFF
--- a/skcosmo/_selection.py
+++ b/skcosmo/_selection.py
@@ -138,7 +138,7 @@ class GreedySelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
                 X,
                 y,
                 accept_sparse="csc",
-                ensure_min_features=2,
+                ensure_min_features=2,#<----------CAUSE ERROR IN CASE OF SAMPLE SELECION FOR DATASET (N, 1)
                 force_all_finite=not tags.get("allow_nan", True),
                 multi_output=True,
             )


### PR DESCRIPTION
PR to attract attention. In case of using selectors (for example, FPS), an error is returned for datasets of size (N, 1), the reason for which I indicated in the comment in the code. It requires checking that the dataset has more than 1 feature, although this is only important for selecting features, not samples. 